### PR TITLE
Compatibility with monoid-subclasses >= 0.4.1 .

### DIFF
--- a/Data/Time/RFC2822.hs
+++ b/Data/Time/RFC2822.hs
@@ -76,9 +76,9 @@ formatsRFC2822 = [ "%a, %e %b %Y %T GMT"
 parseTimeRFC2822 :: (TextualMonoid t) => t -> Maybe ZonedTime
 parseTimeRFC2822 t = foldr (<|>) Nothing $ map parse formatsRFC2822
   where parse :: (TextualMonoid t) => t -> Maybe ZonedTime
-        parse format = parseTime defaultTimeLocale (toString format) t'
+        parse format = parseTime defaultTimeLocale (toString' format) t'
 
         -- t' is a trimmed t (currently only \n is trimmed)
         -- TODO: trim other white space characters
         t' :: String
-        t' = lines (toString t) >>= ("" ++)
+        t' = lines (toString' t) >>= ("" ++)

--- a/Data/Time/Util.hs
+++ b/Data/Time/Util.hs
@@ -3,18 +3,16 @@ module Data.Time.Util where
 import           Control.Applicative
 
 import           Data.Function
-import           Data.Monoid (mempty)
+import           Data.Monoid         (mempty)
 import           Data.Monoid.Textual hiding (foldr, map)
-import           Data.Time.Format (defaultTimeLocale)
 import           Data.Time
+import           Data.Time.Format    (defaultTimeLocale)
 
 
-toString :: (TextualMonoid t) => t -> String
-toString = flip fix mempty $ \recurse output input -> case splitCharacterPrefix input of
-  Just (char, suffix) -> recurse (output ++ [char]) suffix
-  _ -> output
+toString' :: (TextualMonoid t) => t -> String
+toString' = toString (maybe "?" (:[]) . characterPrefix)
 
 parseTimeUsing :: (TextualMonoid t, TextualMonoid t') => [t] -> t' -> Maybe ZonedTime
 parseTimeUsing formats t = foldr (<|>) Nothing $ map parse formats
     where parse :: (TextualMonoid t) => t -> Maybe ZonedTime
-          parse format = parseTime defaultTimeLocale (toString format) (toString t)
+          parse format = parseTime defaultTimeLocale (toString' format) (toString' t)

--- a/timerep.cabal
+++ b/timerep.cabal
@@ -28,7 +28,7 @@ source-repository head
 library
   build-depends:
     base < 5,
-    monoid-subclasses,
+    monoid-subclasses >= 0.4.1,
     text,
     time >= 1.5,
     attoparsec


### PR DESCRIPTION
The `monoid-subclasses` package now exports a `toString` function, let's reuse it.