### PR TITLE
Add non-zero day padding support for RFC822

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,9 @@
 Change log
 ==========
 
+#### 2.0.0.2
+- Added non-zero day padding for RFC822
+
 #### 2.0.0.1
 - Compatibility with monoid-subclasses >= 0.4.1
 - Renamed github repository to match package name

--- a/Data/Time/RFC822.hs
+++ b/Data/Time/RFC822.hs
@@ -42,22 +42,22 @@ formatTimeRFC822 :: (TextualMonoid t) => ZonedTime -> t
 formatTimeRFC822 zonedTime = fromString $ formatTime defaultTimeLocale "%a, %d %b %Y %X %z" zonedTime
 
 formatsRFC822 :: [Text]
-formatsRFC822 = [ "%a, %d %b %y %X %z"
-                , "%a, %d %b %y %X %Z"
-                , "%a, %d %b %y %H:%M %z"
-                , "%a, %d %b %y %H:%M %Z"
-                , "%a, %d %b %Y %X %z"
-                , "%a, %d %b %Y %X %Z"
-                , "%a, %d %b %Y %H:%M %z"
-                , "%a, %d %b %Y %H:%M %Z"
-                , "%d %b %y %X %z"
-                , "%d %b %y %X %Z"
-                , "%d %b %y %H:%M %z"
-                , "%d %b %y %H:%M %Z"
-                , "%d %b %Y %X %z"
-                , "%d %b %Y %X %Z"
-                , "%d %b %Y %H:%M %z"
-                , "%d %b %Y %H:%M %Z"
+formatsRFC822 = [ "%a, %e %b %y %X %z"
+                , "%a, %e %b %y %X %Z"
+                , "%a, %e %b %y %H:%M %z"
+                , "%a, %e %b %y %H:%M %Z"
+                , "%a, %e %b %Y %X %z"
+                , "%a, %e %b %Y %X %Z"
+                , "%a, %e %b %Y %H:%M %z"
+                , "%a, %e %b %Y %H:%M %Z"
+                , "%e %b %y %X %z"
+                , "%e %b %y %X %Z"
+                , "%e %b %y %H:%M %z"
+                , "%e %b %y %H:%M %Z"
+                , "%e %b %Y %X %z"
+                , "%e %b %Y %X %Z"
+                , "%e %b %Y %H:%M %z"
+                , "%e %b %Y %H:%M %Z"
                 ]
 
 parseTimeRFC822 :: (TextualMonoid t) => t -> Maybe ZonedTime

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -92,8 +92,10 @@ casesRFC822 = testCase "RFC 822 cases" $ do
   isJust (parseTimeRFC822 "Wed, 02 Oct 2002 13:00:00 GMT") @?= True
   isJust (parseTimeRFC822 "Wed, 02 Oct 2002 13:00:00 +0100") @?= True
   isJust (parseTimeRFC822 "Wed, 02 Oct 2002 13:00 +0100") @?= True
+  isJust (parseTimeRFC822 "Wed, 2 Oct 2002 13:00 +0100") @?= True
   isJust (parseTimeRFC822 "02 Oct 2002 13:00 +0100") @?= True
   isJust (parseTimeRFC822 "02 Oct 02 13:00 +0100") @?= True
+  isJust (parseTimeRFC822 "2 Oct 02 13:00 +0100") @?= True
 
 
 properties :: TestTree


### PR DESCRIPTION
RFC822 allows for day to be either one or two digits, thus zero
padding is optional.