### PR TITLE
fix: Compatibility with recent versions of `time` dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         cabal: ["3.2"]
-        ghc: ["8.4.4", "8.6.5", "8.8.4", "8.10.2"]
+        ghc: ["8.4.4", "8.6.5", "8.8.4", "8.10.2", "9.0.2", "9.2.3"]
     env:
       CONFIG: "--enable-tests --enable-benchmarks"
     steps:

--- a/Data/Time/RFC2822.hs
+++ b/Data/Time/RFC2822.hs
@@ -49,7 +49,7 @@ import           Data.Monoid.Textual        hiding (foldr, map)
 import           Data.String                (fromString)
 import           Data.Text                  (Text)
 import           Data.Time.Calendar
-import           Data.Time.Format
+import           Data.Time.Format           (defaultTimeLocale, formatTime, parseTimeM)
 import           Data.Time.LocalTime
 import           Data.Time.Util
 
@@ -71,9 +71,8 @@ formatsRFC2822 = do
 parseTimeRFC2822 :: (TextualMonoid t) => t -> Maybe ZonedTime
 parseTimeRFC2822 t = foldr (<|>) Nothing $ map parse formatsRFC2822
   where parse :: (TextualMonoid t) => t -> Maybe ZonedTime
-        parse format = parseTime defaultTimeLocale (toString' format) t'
+        parse format = parseTimeM True defaultTimeLocale (toString' format) t'
 
         -- t' is a trimmed t (currently only \n is trimmed)
-        -- TODO: trim other white space characters
         t' :: String
         t' = lines (toString' t) >>= ("" ++)

--- a/timerep.cabal
+++ b/timerep.cabal
@@ -1,5 +1,5 @@
 name:          timerep
-version:       2.0.1.0
+version:       2.1.0.0
 category:      Web, Time, Parser, Text
 synopsis:      Parse and display time according to some RFCs (RFC3339, RFC2822, RFC822)
 description:

--- a/timerep.cabal
+++ b/timerep.cabal
@@ -37,7 +37,7 @@ library
     base < 5,
     monoid-subclasses >= 0.4.1,
     text,
-    time >= 1.5,
+    time >= 1.9,
     attoparsec
 
   exposed-modules:
@@ -62,5 +62,5 @@ test-suite Tests
     tasty-hunit,
     tasty-quickcheck,
     text,
-    time >= 1.5,
+    time >= 1.9,
     timerep >= 2


### PR DESCRIPTION
Fixes https://github.com/HugoDaniel/timerep/issues/19 .

Function `parseTime`:
- [exists in `time ==1.9`](https://hackage.haskell.org/package/time-1.9/docs/doc-index-P.html)
- [doesn't exist in `time >=1.10`](https://hackage.haskell.org/package/time-1.10/docs/doc-index-P.html)